### PR TITLE
Event Store 에 publish 되고 나면 event 목록을 clear 한다.

### DIFF
--- a/domain/src/test/java/io/agistep/todo/domain/TodoCreatedEventTest.java
+++ b/domain/src/test/java/io/agistep/todo/domain/TodoCreatedEventTest.java
@@ -20,6 +20,8 @@ class TodoCreatedEventTest {
 
 	@BeforeEach
 	void setUp() {
+		EventList.instance().publish();
+
 		sut = new Todo("Some Text");
 
 	}
@@ -27,10 +29,5 @@ class TodoCreatedEventTest {
 	void properties() {
 		assertThat(sut.getText()).isEqualTo("Some Text");
 		assertThat(sut.isDone()).isEqualTo(false);
-	}
-
-	@AfterEach
-	void tearDown() {
-		EventList.instance().clean();
 	}
 }

--- a/domain/src/test/java/io/agistep/todo/domain/TodoDoneEventTest.java
+++ b/domain/src/test/java/io/agistep/todo/domain/TodoDoneEventTest.java
@@ -16,6 +16,7 @@ class TodoDoneEventTest {
 
 	@BeforeEach
 	void setUp() {
+		EventList.instance().publish();
 		sut = Todo.replay(Events.mock(1919, 1, TodoCreated.newBuilder().setText("Some Text").build()));
 	}
 
@@ -30,10 +31,5 @@ class TodoDoneEventTest {
 		assertThat(sut.isDone()).isFalse();
 		sut.done();
 		assertThat(sut.isDone()).isTrue();
-	}
-
-	@AfterEach
-	void tearDown() {
-		EventList.instance().clean();
 	}
 }

--- a/event-core/src/main/java/io/agistep/event/EventList.java
+++ b/event-core/src/main/java/io/agistep/event/EventList.java
@@ -15,5 +15,6 @@ public interface EventList {
 
 	List<Event> occurredListBy(Object aggregate);
 
-	void clean();
+	void publish();
+
 }

--- a/event-core/src/main/java/io/agistep/event/ThreadLocalEventList.java
+++ b/event-core/src/main/java/io/agistep/event/ThreadLocalEventList.java
@@ -41,7 +41,7 @@ class ThreadLocalEventList implements EventList {
 	}
 
 	private static boolean isEmpty(List<Event> events) {
-		return events == null;
+		return events == null || events.isEmpty();
 	}
 
 	@Override
@@ -51,7 +51,9 @@ class ThreadLocalEventList implements EventList {
 	}
 
 	@Override
-	public void clean() {
+	public void publish() {
+		// TODO 이벤트 스토어에 저장 요청
 		changes.remove();
+
 	}
 }

--- a/event-core/src/test/java/io/agistep/event/ThreadLocalEventListTest.java
+++ b/event-core/src/test/java/io/agistep/event/ThreadLocalEventListTest.java
@@ -1,0 +1,42 @@
+package io.agistep.event;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+class ThreadLocalEventListTest {
+
+
+    private ThreadLocalEventList sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = (ThreadLocalEventList) ThreadLocalEventList.instance();
+        sut.publish();
+    }
+
+    @Test
+    void create() {
+        assertThat(sut).isInstanceOf(ThreadLocalEventList.class);
+    }
+
+    @Test
+    void occursTest() {
+        long aggregateId = 1L;
+        sut.occurs(Events.mock(aggregateId, -1, new FooEventPayload()));
+
+        List<Event> actual = sut.occurredListAll();
+        assertThat(actual).hasSize(1);
+        Event event = actual.get(0);
+        assertThat(event.getAggregateIdValue()).isEqualTo(aggregateId);
+        assertThat(event.getPayload()).isInstanceOf(FooEventPayload.class);
+
+    }
+
+    private static class FooEventPayload {
+    }
+
+}


### PR DESCRIPTION
아직 publish 의 구현이 되어있지 않아, 가상의 publish 메소드 내에서 publish 후, clear 합니다.

그 외로 ThreadLocalEventList 테스트 코드 추가

closed #10