### PR TITLE
Add MethodHelper to invoke various method params of eventHandler

### DIFF
--- a/event/core/src/main/java/io/agistep/event/EventReorganizer.java
+++ b/event/core/src/main/java/io/agistep/event/EventReorganizer.java
@@ -34,13 +34,13 @@ final class EventReorganizer {
 	private static HandlerAdapter initHandler(Object aggregate) {
 		final String aggregateName = aggregate.getClass().getName();
 		List<Method> eventHandlerMethods = AnnotationHelper.getMethodsListWithAnnotation(aggregate.getClass(), EventHandler.class);
-		List<Pair<EventHandler, Method>> aa = eventHandlerMethods.stream().map(m -> {
+		List<Pair<EventHandler, Method>> handlerMethodPairs = eventHandlerMethods.stream().map(m -> {
 			EventHandler annotation = AnnotationHelper.getAnnotation(m, EventHandler.class);
 
 			return Pair.of(annotation, m);
 		}).collect(toList());
 
-		return new HandlerAdapter(aggregateName, aa);
+		return new HandlerAdapter(aggregateName, handlerMethodPairs);
 	}
 
 	final static Map<String, HandlerAdapter> handlers = new HashMap<>();

--- a/event/core/src/main/java/io/agistep/event/HandlerAdapter.java
+++ b/event/core/src/main/java/io/agistep/event/HandlerAdapter.java
@@ -24,10 +24,12 @@ class HandlerAdapter {
 	public void handle(Object aggregate, Event anEvent) {
 		String eventName = anEvent.getName();
 
-		Pair<EventHandler, Method> aa = handlerMethods.stream().filter(hm -> hm.getKey().payload().getName().equals(eventName)).findFirst().get();
+		Pair<EventHandler, Method> handlerMethodPair = handlerMethods.stream()
+				.filter(hm -> hm.getKey().payload().getName().equals(eventName))
+				.findFirst().get();
 
 		try {
-			Method method = aa.getValue();
+			Method method = handlerMethodPair.getValue();
 			method.setAccessible(true);
 			method.invoke(aggregate, anEvent);
 		} catch (InvocationTargetException | IllegalAccessException e) {

--- a/event/core/src/main/java/io/agistep/event/HandlerAdapter.java
+++ b/event/core/src/main/java/io/agistep/event/HandlerAdapter.java
@@ -1,5 +1,6 @@
 package io.agistep.event;
 
+import io.agistep.utils.MethodHelper;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.lang.reflect.InvocationTargetException;
@@ -31,9 +32,11 @@ class HandlerAdapter {
 		try {
 			Method method = handlerMethodPair.getValue();
 			method.setAccessible(true);
-			method.invoke(aggregate, anEvent);
+
+			MethodHelper.invoke(aggregate, anEvent, method);
 		} catch (InvocationTargetException | IllegalAccessException e) {
 			throw new RuntimeException(e);
 		}
 	}
+
 }

--- a/event/core/src/main/java/io/agistep/utils/MethodHelper.java
+++ b/event/core/src/main/java/io/agistep/utils/MethodHelper.java
@@ -1,0 +1,29 @@
+package io.agistep.utils;
+
+import io.agistep.event.Event;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+
+public class MethodHelper {
+
+    public static void invoke(Object aggregate, Event anEvent, Method method) throws IllegalAccessException, InvocationTargetException {
+        Parameter[] parameters = method.getParameters();
+
+        if (parameters == null || parameters.length == 0) {
+            return;
+        }
+
+        if (parameters.length > 1) {
+            Class<?> secondParameterType = parameters[1].getType();
+
+            if (Long.class.isAssignableFrom(secondParameterType)) {
+                method.invoke(aggregate, anEvent.getPayload(), anEvent.getAggregateId());
+                return;
+            }
+        }
+
+        method.invoke(aggregate, anEvent);
+    }
+}

--- a/event/core/src/test/java/io/agistep/utils/MethodHelperTest.java
+++ b/event/core/src/test/java/io/agistep/utils/MethodHelperTest.java
@@ -1,0 +1,68 @@
+package io.agistep.utils;
+
+import io.agistep.event.Event;
+import io.agistep.foo.FooCreated;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+class MethodHelperTest {
+
+    @Test
+    @DisplayName("invoke method with parameter of Event")
+    void invoke0() throws Exception {
+        FooAggregate aggregate = spy(new FooAggregate());
+        Event event = mock(Event.class);
+        Method method = FooAggregate.class.getMethod("methodWithOneEventParam", Event.class);
+
+        MethodHelper.invoke(aggregate, event, method);
+
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(aggregate).methodWithOneEventParam(eventCaptor.capture());
+
+        assertSame(event, eventCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("invoke method with parameters of payload and aggregate id")
+    void invoke1() throws Exception {
+        FooAggregate aggregate = spy(new FooAggregate());
+
+        Event event = mock(Event.class);
+        when(event.getAggregateId()).thenReturn(1L);
+        FooCreated payload = new FooCreated();
+        when(event.getPayload()).thenReturn(payload);
+
+        Method method = FooAggregate.class.getMethod("methodWithTwoParams", Object.class, Long.class);
+
+        MethodHelper.invoke(aggregate, event, method);
+
+        verify(aggregate).methodWithTwoParams(payload, 1L);
+    }
+
+    @Test
+    @DisplayName("invoke method with invalid parameters")
+    void invoke2() throws NoSuchMethodException {
+        Object aggregate = new FooAggregate();
+        Event event = mock(Event.class);
+        Method method = FooAggregate.class.getMethod("methodWithInvalidParams", String.class, String.class);
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            MethodHelper.invoke(aggregate, event, method);
+        });
+    }
+
+    static class FooAggregate {
+        public void methodWithOneEventParam(Event event) {}
+
+        public void methodWithTwoParams(Object payload, Long aggregateId) {}
+
+        public void methodWithInvalidParams(String param1, String param2) {}
+    }
+}

--- a/event/core/src/test/java/io/agistep/utils/MethodHelperTest.java
+++ b/event/core/src/test/java/io/agistep/utils/MethodHelperTest.java
@@ -15,40 +15,20 @@ import static org.mockito.Mockito.*;
 class MethodHelperTest {
 
     @Test
-    @DisplayName("invoke method with parameter of Event")
-    void invoke0() throws Exception {
-        FooAggregate aggregate = spy(new FooAggregate());
+    @DisplayName("Exception: invoke method with no parameters")
+    void invoke0() throws NoSuchMethodException {
+        Object aggregate = new FooAggregate();
         Event event = mock(Event.class);
-        Method method = FooAggregate.class.getMethod("methodWithOneEventParam", Event.class);
+        Method method = FooAggregate.class.getMethod("methodWithNoParams");
 
-        MethodHelper.invoke(aggregate, event, method);
-
-        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-        verify(aggregate).methodWithOneEventParam(eventCaptor.capture());
-
-        assertSame(event, eventCaptor.getValue());
-    }
-
-    @Test
-    @DisplayName("invoke method with parameters of payload and aggregate id")
-    void invoke1() throws Exception {
-        FooAggregate aggregate = spy(new FooAggregate());
-
-        Event event = mock(Event.class);
-        when(event.getAggregateId()).thenReturn(1L);
-        FooCreated payload = new FooCreated();
-        when(event.getPayload()).thenReturn(payload);
-
-        Method method = FooAggregate.class.getMethod("methodWithTwoParams", Object.class, Long.class);
-
-        MethodHelper.invoke(aggregate, event, method);
-
-        verify(aggregate).methodWithTwoParams(payload, 1L);
+        assertThrows(IllegalArgumentException.class, () -> {
+            MethodHelper.invoke(aggregate, event, method);
+        });
     }
 
     @Test
     @DisplayName("invoke method with invalid parameters")
-    void invoke2() throws NoSuchMethodException {
+    void invoke1() throws NoSuchMethodException {
         Object aggregate = new FooAggregate();
         Event event = mock(Event.class);
         Method method = FooAggregate.class.getMethod("methodWithInvalidParams", String.class, String.class);
@@ -58,8 +38,72 @@ class MethodHelperTest {
         });
     }
 
+    @Test
+    @DisplayName("invoke method with parameter of Event")
+    void invoke2() throws Exception {
+        // given
+        FooAggregate aggregate = spy(new FooAggregate());
+        Event event = mock(Event.class);
+        Method method = FooAggregate.class.getMethod("methodWithOneEventParam", Event.class);
+
+        // when
+        MethodHelper.invoke(aggregate, event, method);
+
+        // then
+        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(aggregate).methodWithOneEventParam(eventCaptor.capture());
+
+        assertSame(event, eventCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("invoke method with parameter of payload")
+    void invoke3() throws Exception {
+        // given
+        FooAggregate aggregate = spy(new FooAggregate());
+
+        Event event = mock(Event.class);
+        FooCreated payload = new FooCreated();
+        when(event.getPayload()).thenReturn(payload);
+
+        Method method = FooAggregate.class.getMethod("methodWithOnePayloadParam", Object.class);
+
+        // when
+        MethodHelper.invoke(aggregate, event, method);
+
+        // then
+        ArgumentCaptor<FooCreated> payloadCaptor = ArgumentCaptor.forClass(FooCreated.class);
+        verify(aggregate).methodWithOnePayloadParam(payloadCaptor.capture());
+
+        assertSame(payload, payloadCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("invoke method with parameters of payload and aggregate id")
+    void invoke4() throws Exception {
+        // given
+        FooAggregate aggregate = spy(new FooAggregate());
+
+        Event event = mock(Event.class);
+        when(event.getAggregateId()).thenReturn(1L);
+        FooCreated payload = new FooCreated();
+        when(event.getPayload()).thenReturn(payload);
+
+        Method method = FooAggregate.class.getMethod("methodWithTwoParams", Object.class, Long.class);
+
+        // when
+        MethodHelper.invoke(aggregate, event, method);
+
+        // then
+        verify(aggregate).methodWithTwoParams(payload, 1L);
+    }
+
     static class FooAggregate {
+        public void methodWithNoParams() {}
+
         public void methodWithOneEventParam(Event event) {}
+
+        public void methodWithOnePayloadParam(Object payload) {}
 
         public void methodWithTwoParams(Object payload, Long aggregateId) {}
 

--- a/event/fixtures/src/main/java/io/agistep/foo/Foo.java
+++ b/event/fixtures/src/main/java/io/agistep/foo/Foo.java
@@ -14,7 +14,7 @@ public class Foo {
 
     @EventHandler(payload= FooCreated.class)
     void onCreated(Event anEvent) {
-        this.id = (Long) anEvent.getAggregateId();
+        this.id = anEvent.getAggregateId();
     }
 
     @EventHandler(payload=FooDone.class)

--- a/examples/todo/domain/src/main/java/io/agistep/todo/domain/Todo.java
+++ b/examples/todo/domain/src/main/java/io/agistep/todo/domain/Todo.java
@@ -42,7 +42,7 @@ public class Todo {
 	}
 
 	@EventHandler(payload = TodoDone.class)
-	void onDone(Event anEvent) {
+	void onDone(TodoDone done) {
 		this.done = true;
 	}
 
@@ -52,8 +52,8 @@ public class Todo {
 	}
 
 	@EventHandler(payload = TodoTextUpdated.class)
-	void onTextUpdated(Event anEvent) {
-		this.text = ((TodoTextUpdated) anEvent.getPayload()).getUpdatedText();
+	void onTextUpdated(TodoTextUpdated payload) {
+		this.text = payload.getUpdatedText();
 	}
 
 	public void hold() {
@@ -68,6 +68,5 @@ public class Todo {
 	void onHeld(Event anEvent) {
 		this.hold = true;
 	}
-
 
 }

--- a/examples/todo/domain/src/main/java/io/agistep/todo/domain/Todo.java
+++ b/examples/todo/domain/src/main/java/io/agistep/todo/domain/Todo.java
@@ -27,9 +27,9 @@ public class Todo {
 	}
 
 	@EventHandler(payload = TodoCreated.class)
-	void onCreated(Event anEvent) {
-		this.id = anEvent.getAggregateId();
-		this.text = ((TodoCreated) anEvent.getPayload()).getText();
+	void onCreated(TodoCreated created, Long aggregateId) {
+		this.id = aggregateId;
+		this.text = created.getText();
 		this.done = false;
 	}
 

--- a/examples/todo/domain/src/main/java/io/agistep/todo/domain/Todo.java
+++ b/examples/todo/domain/src/main/java/io/agistep/todo/domain/Todo.java
@@ -28,7 +28,7 @@ public class Todo {
 
 	@EventHandler(payload = TodoCreated.class)
 	void onCreated(Event anEvent) {
-		this.id = (Long) anEvent.getAggregateId();
+		this.id = anEvent.getAggregateId();
 		this.text = ((TodoCreated) anEvent.getPayload()).getText();
 		this.done = false;
 	}

--- a/examples/todo/domain/src/test/java/io/agistep/todo/domain/TodoHeldEventTest.java
+++ b/examples/todo/domain/src/test/java/io/agistep/todo/domain/TodoHeldEventTest.java
@@ -8,10 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.agistep.event.test.EventSourcingAssertions.assertEventSourcing;
 
-class TodoHeldEvenTest {
-
-
-    Todo sut;
+class TodoHeldEventTest {
 
     @BeforeEach
     void setUp() {

--- a/examples/todo/domain/src/test/java/io/agistep/todo/domain/TodoUpdatedEventTest.java
+++ b/examples/todo/domain/src/test/java/io/agistep/todo/domain/TodoUpdatedEventTest.java
@@ -1,0 +1,40 @@
+package io.agistep.todo.domain;
+
+import io.agistep.event.EventSource;
+import io.agistep.event.test.HoldingEventListener;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.agistep.event.test.EventSourcingAssertions.assertEventSourcing;
+
+class TodoUpdatedEventTest {
+
+
+    @BeforeEach
+    void setUp() {
+        EventSource.setListener(new HoldingEventListener());
+    }
+
+    @AfterEach
+    void tearDown() {
+        EventSource.setListener(null);
+    }
+
+    @Test
+    void done() {
+        TodoCreated created = TodoCreated.newBuilder().setText("Some Text").build();
+
+        String updatedText = "Updated Text";
+        assertEventSourcing(Todo::new)
+                .given(created)
+
+                .when(e -> e.updateText(updatedText))
+
+                .expected(TodoTextUpdated.newBuilder().setUpdatedText(updatedText).build())
+
+				.extracting("text").isEqualTo(updatedText);
+    }
+
+
+}


### PR DESCRIPTION
### Updates

- as-is: for a method of an aggregate to use `@EventHandler` the parameter should only be `foo(Event event)`
- to-be: method parameter can be `foo(Object payload)` or `foo(Object payload, Long aggregateId)`


### to think
🤔 요런 파라미터를 써야한다는 것을 사용자에게 어떻게 강제하거나 알려줄 수 있을지???