### PR TITLE
EventApplier 에서 EventMaker 분리

### DIFF
--- a/event/core/src/main/java/io/agistep/event/EventMaker.java
+++ b/event/core/src/main/java/io/agistep/event/EventMaker.java
@@ -11,21 +11,6 @@ import static org.valid4j.Validation.validate;
 
 public class EventMaker {
 
-    public static EventBuilder builder() {
-        return new EventBuilder();
-    }
-
-    static Event make(long eventId, long aggregateId, long nextSeq, String eventName, LocalDateTime occurredAt, Object payload) {
-        return EventBuilder.builder()
-                .id(eventId)
-                .name(eventName)
-                .aggregateId(aggregateId)
-                .seq(nextSeq)
-                .payload(payload)
-                .occurredAt(occurredAt)
-                .build();
-    }
-
     static Event make(Object aggregate, Object payload) {
         final long eventId = IdUtils.gen();
         final long aggregateId;
@@ -39,18 +24,22 @@ public class EventMaker {
             nextSeq = nextSeq(aggregateId);
         }
 
-        return EventBuilder.builder()
-                .id(eventId)
-                .name(payload.getClass().getName())
-                .aggregateId(aggregateId)
-                .seq(nextSeq)
-                .payload(payload)
-                .occurredAt(LocalDateTime.now())
-                .build();
+        return make(eventId, aggregateId, nextSeq, payload.getClass().getName(), LocalDateTime.now(), payload);
     }
 
     private static long nextSeq(Object aggregateId) {
         return ThreadLocalEventSeqHolder.instance().nextSeq((Long) aggregateId);
+    }
+
+    public static Event make(long eventId, long aggregateId, long nextSeq, String eventName, LocalDateTime occurredAt, Object payload) {
+        return EventBuilder.builder()
+                .id(eventId)
+                .name(eventName)
+                .aggregateId(aggregateId)
+                .seq(nextSeq)
+                .payload(payload)
+                .occurredAt(occurredAt)
+                .build();
     }
 
     private static final class EventBuilder {
@@ -186,5 +175,29 @@ public class EventMaker {
                     ", occurredAt=" + occurredAt +
                     '}';
         }
+    }
+
+    public static Object payload(Object payload) {
+        return payload;
+    }
+
+    public static String eventName(String name) {
+        return name;
+    }
+
+    public static LocalDateTime occurredAt(LocalDateTime dateTime) {
+        return dateTime;
+    }
+
+    public static long seq(long seq) {
+        return seq;
+    }
+
+    public static long aggregateId(long id) {
+        return id;
+    }
+
+    public static long eventId(long id) {
+        return id;
     }
 }

--- a/event/core/src/main/java/io/agistep/event/EventMaker.java
+++ b/event/core/src/main/java/io/agistep/event/EventMaker.java
@@ -1,0 +1,190 @@
+package io.agistep.event;
+
+import io.agistep.aggregator.IdUtils;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.valid4j.Assertive.require;
+import static org.valid4j.Validation.validate;
+
+public class EventMaker {
+
+    public static EventBuilder builder() {
+        return new EventBuilder();
+    }
+
+    static Event make(long eventId, long aggregateId, long nextSeq, String eventName, LocalDateTime occurredAt, Object payload) {
+        return EventBuilder.builder()
+                .id(eventId)
+                .name(eventName)
+                .aggregateId(aggregateId)
+                .seq(nextSeq)
+                .payload(payload)
+                .occurredAt(occurredAt)
+                .build();
+    }
+
+    static Event make(Object aggregate, Object payload) {
+        final long eventId = IdUtils.gen();
+        final long aggregateId;
+        final long nextSeq;
+
+        if (IdUtils.notAssignedIdOf(aggregate)) {
+            aggregateId = IdUtils.gen();
+            nextSeq = EventSource.INITIAL_SEQ;
+        } else {
+            aggregateId = IdUtils.idOf(aggregate);
+            nextSeq = nextSeq(aggregateId);
+        }
+
+        return EventBuilder.builder()
+                .id(eventId)
+                .name(payload.getClass().getName())
+                .aggregateId(aggregateId)
+                .seq(nextSeq)
+                .payload(payload)
+                .occurredAt(LocalDateTime.now())
+                .build();
+    }
+
+    private static long nextSeq(Object aggregateId) {
+        return ThreadLocalEventSeqHolder.instance().nextSeq((Long) aggregateId);
+    }
+
+    private static final class EventBuilder {
+        private Long id;
+        private String name;
+        private Long seq;
+        private Long aggregateId;
+        private Object payload;
+        private LocalDateTime occurredAt;
+
+        private EventBuilder() {}
+
+        public static EventBuilder builder() {
+            return new EventBuilder();
+        }
+
+        public Event build() {
+            validate(name.equals(payload.getClass().getName()), new IllegalArgumentException("Event name should be same with payload class name."));
+
+            if(this.occurredAt == null) {
+                this.occurredAt(LocalDateTime.now());
+            }
+
+            return new ObjectPayloadEnvelop(
+                    require(id, is(not(nullValue()))),
+                    name,
+                    seq,
+                    aggregateId,
+                    payload,
+                    occurredAt);
+        }
+
+        public EventBuilder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public EventBuilder id(long id) {
+            this.id = id;
+            return this;
+        }
+
+        public EventBuilder seq(long seq) {
+            this.seq = seq;
+            return this;
+        }
+
+        public EventBuilder aggregateId(Long aggregateId) {
+            this.aggregateId = aggregateId;
+            return this;
+        }
+
+        public EventBuilder payload(Object payload) {
+            this.payload = payload;
+            return this;
+        }
+
+        public EventBuilder occurredAt(LocalDateTime occurredAt) {
+            this.occurredAt = occurredAt;
+            return this;
+        }
+
+    }
+
+    private static class ObjectPayloadEnvelop implements Event {
+        private final long id;
+        private final String name;
+        private final long seq;
+        private final Long aggregateId;
+        private final Object payload;
+        private final LocalDateTime occurredAt;
+
+        private ObjectPayloadEnvelop(long id, String name, long seq, Long aggregateId, Object payload, LocalDateTime occurredAt) {
+            this.id = id;
+            this.name = name;
+            this.seq = seq;
+            this.aggregateId = aggregateId;
+            this.payload = payload;
+            this.occurredAt = occurredAt;
+        }
+
+        @Override
+        public long getId() {
+            return id;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public long getSeq() {
+            return seq;
+        }
+
+        @Override
+        public long getAggregateId() {
+            return aggregateId;
+        }
+
+        @Override
+        public Object getPayload() {
+            return payload;
+        }
+
+        @Override
+        public LocalDateTime getOccurredAt() {
+            return occurredAt;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ObjectPayloadEnvelop that = (ObjectPayloadEnvelop) o;
+            return seq == that.seq && Objects.equals(aggregateId, that.aggregateId) && Objects.equals(name, that.name) && Objects.equals(payload, that.payload) && Objects.equals(occurredAt, that.occurredAt);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, seq, aggregateId, payload, occurredAt);
+        }
+
+        @Override
+        public String toString() {
+            return "ObjectPayloadEnvelop{" +
+                    "id=" + id +
+                    ", name='" + name + '\'' +
+                    ", seq=" + seq +
+                    ", aggregateId=" + aggregateId +
+                    ", payload=" + payload +
+                    ", occurredAt=" + occurredAt +
+                    '}';
+        }
+    }
+}

--- a/event/core/src/main/java/io/agistep/event/EventSource.java
+++ b/event/core/src/main/java/io/agistep/event/EventSource.java
@@ -19,10 +19,6 @@ public final class EventSource {
         /* This is Utility */
     }
 
-    public static EventBuilder builder() {
-        return new EventBuilder();
-    }
-
     public static void apply(Object aggregate, Object payload) {
         EventApplier.apply(aggregate, payload);
     }

--- a/event/core/src/test/java/io/agistep/event/EventMakerTest.java
+++ b/event/core/src/test/java/io/agistep/event/EventMakerTest.java
@@ -1,0 +1,55 @@
+package io.agistep.event;
+
+import io.agistep.foo.Foo;
+import io.agistep.foo.FooCreated;
+import io.agistep.foo.FooDone;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class EventMakerTest extends EventApplySupport {
+
+    @Test
+    @DisplayName("Exception: make event with invalid event name")
+    void eventName() {
+        FooCreated payload = new FooCreated();
+        assertThatThrownBy(() -> EventMaker.make(
+                1L,
+                1L,
+                0L,
+                "invalid_event_name",
+                LocalDateTime.of(2023, 12, 12, 0, 0),
+                payload
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Event name should be same with payload class name.");
+    }
+
+
+    @Test
+    @DisplayName("make event")
+    void makeEvent() {
+        Foo aggregate = new Foo();
+
+        FooCreated fooCreated = new FooCreated();
+        String createdEventName = fooCreated.getClass().getName();
+        EventSource.apply(aggregate, fooCreated);
+
+        assertThat(aggregate.isDone()).isFalse();
+        assertThat(EventSource.getHoldEvents(aggregate).get(0).getName()).isEqualTo(createdEventName);
+        assertThat(EventSource.getLatestSeqOf(aggregate)).isEqualTo(EventSource.INITIAL_SEQ);
+
+        FooDone fooDone = new FooDone();
+        String doneEventName = fooDone.getClass().getName();
+        EventSource.apply(aggregate, fooDone);
+
+        assertThat(aggregate.isDone()).isTrue();
+        assertThat(EventSource.getHoldEvents(aggregate)).hasSize(2);
+        assertThat(EventSource.getHoldEvents(aggregate).get(1).getName()).isEqualTo(doneEventName);
+        assertThat(EventSource.getLatestSeqOf(aggregate)).isEqualTo(EventSource.INITIAL_SEQ +1);
+    }
+}

--- a/event/core/src/test/java/io/agistep/event/Event_Equal_Test.java
+++ b/event/core/src/test/java/io/agistep/event/Event_Equal_Test.java
@@ -13,22 +13,26 @@ class Event_Equal_Test {
 
     @Test
     void equals() {
-        Event anEvent = EventSource.builder()
-                .id(1L)
-                .seq(0L)
-                .aggregateId(1L)
-                .payload(new JsonPayloadTest("Test anEvent"))
-                .occurredAt(LocalDateTime.of(2023,12,12,0,0))
-                .build();
 
-        Event anEvent2 = EventSource.builder()
-                .id(1L)
-                .seq(0L)
+        JsonPayloadTest test_anEvent = new JsonPayloadTest("Test anEvent");
+        Event anEvent = EventMaker.make(
+                1L,
+                1L,
+                0L,
+                test_anEvent.getClass().getName(),
+                LocalDateTime.of(2023,12,12,0,0),
+                test_anEvent
+        );
 
-                .aggregateId(1L)
-                .payload(new JsonPayloadTest("Test anEvent"))
-                .occurredAt(LocalDateTime.of(2023,12,12,0,0))
-                .build();
+        JsonPayloadTest test_anEvent2 = new JsonPayloadTest("Test anEvent");
+        Event anEvent2 = EventMaker.make(
+                1L,
+                1L,
+                0L,
+                test_anEvent2.getClass().getName(),
+                LocalDateTime.of(2023,12,12,0,0),
+                test_anEvent
+        );
 
         assertThat(anEvent).isEqualTo(anEvent2);
     }

--- a/event/core/src/test/java/io/agistep/event/ThreadLocalEventHolderTest.java
+++ b/event/core/src/test/java/io/agistep/event/ThreadLocalEventHolderTest.java
@@ -31,13 +31,7 @@ class ThreadLocalEventHolderTest extends EventApplySupport {
     void occursTest() {
         long aggregateId = 1L;
         Object payload = new FooEventPayload();
-        sut.hold(EventSource.builder()
-                        .id(1L)
-                .seq(EventSource.INITIAL_SEQ)
-                .aggregateId(aggregateId)
-                .payload(payload)
-                .occurredAt(LocalDateTime.now())
-                .build());
+        sut.hold(EventMaker.make(1L, aggregateId, EventSource.INITIAL_SEQ, payload.getClass().getName(), LocalDateTime.now(), payload));
 
         List<Event> actual = sut.getEventAll();
         assertThat(actual).hasSize(1);

--- a/event/storage-csv/src/main/java/io/agistep/event/storages/CSVFileEventStorage.java
+++ b/event/storage-csv/src/main/java/io/agistep/event/storages/CSVFileEventStorage.java
@@ -1,9 +1,6 @@
 package io.agistep.event.storages;
 
-import io.agistep.event.Deserializer;
-import io.agistep.event.Event;
-import io.agistep.event.EventSource;
-import io.agistep.event.Serializer;
+import io.agistep.event.*;
 import io.agistep.event.serialization.ProtocolBufferDeserializer;
 import io.agistep.event.serialization.ProtocolBufferSerializer;
 import org.apache.commons.csv.CSVFormat;
@@ -13,10 +10,10 @@ import org.apache.commons.csv.CSVRecord;
 import java.io.*;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.agistep.event.EventMaker.*;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
 class CSVFileEventStorage extends OptimisticLockingSupport {
@@ -103,13 +100,13 @@ class CSVFileEventStorage extends OptimisticLockingSupport {
     private static Event getEvent(CSVRecord record) {
         Object deserialize = deserialize(record);
 
-        return EventSource.builder()
-                .id(Long.parseLong(record.get("id")))
-                .seq(Long.parseLong(record.get("seq")))
-                .aggregateId(Long.parseLong(record.get("aggregateId")))
-                .payload(deserialize)
-                .occurredAt(LocalDateTime.parse(record.get("occurredAt"), DateTimeFormatter.ISO_LOCAL_DATE_TIME))
-                .build();
+        return EventMaker.make(
+                eventId(Long.parseLong(record.get("id"))),
+                aggregateId(Long.parseLong(record.get("aggregateId"))),
+                seq(Long.parseLong(record.get("seq"))),
+                eventName(deserialize.getClass().getName()),
+                occurredAt(LocalDateTime.parse(record.get("occurredAt"), ISO_LOCAL_DATE_TIME)),
+                payload(deserialize));
     }
 
     private static Object deserialize(CSVRecord record) {

--- a/event/storage-jdbc/src/main/java/io/agistep/event/storages/JDBCEventStorage.java
+++ b/event/storage-jdbc/src/main/java/io/agistep/event/storages/JDBCEventStorage.java
@@ -15,6 +15,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import static io.agistep.event.EventMaker.*;
+
 class JDBCEventStorage extends OptimisticLockingSupport {
     static final String INSERT_DML = "INSERT INTO events" +
             "(id, seq, name, aggregateId, payload, occurredAt)" +
@@ -117,12 +119,14 @@ class JDBCEventStorage extends OptimisticLockingSupport {
                         .orElseThrow(UnsupportedOperationException::new);
 
                 Object deserialize = deserializer.deserialize(String.valueOf(payload).getBytes(StandardCharsets.UTF_8));
-                Event anEvent = EventSource.builder()
-                        .id(rs.getLong("id"))
-                        .aggregateId(rs.getLong("aggregateId"))
-                        .seq(rs.getLong("seq"))
-                        .payload(deserialize)
-                        .occurredAt(timestamp.toLocalDateTime()).build();
+                Event anEvent = EventMaker.make(
+                        eventId(rs.getLong("id")),
+                        aggregateId(rs.getLong("aggregateId")),
+                        seq(rs.getLong("seq")),
+                        eventName(deserialize.getClass().getName()),
+                        occurredAt(timestamp.toLocalDateTime()),
+                        payload(deserialize)
+                );
                 events.add(anEvent);
             }
         } catch (SQLException e) {

--- a/event/storage-jdbc/src/test/java/io/agistep/event/storages/JDBCEventStorage_JSON_Test.java
+++ b/event/storage-jdbc/src/test/java/io/agistep/event/storages/JDBCEventStorage_JSON_Test.java
@@ -1,13 +1,14 @@
 package io.agistep.event.storages;
 
 import io.agistep.event.Event;
-import io.agistep.event.EventSource;
+import io.agistep.event.EventMaker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static io.agistep.event.EventMaker.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JDBCEventStorage_JSON_Test {
@@ -27,14 +28,7 @@ class JDBCEventStorage_JSON_Test {
     void saveAndFind() {
 
         Person john = new Person("John", 30);
-
-        Event e = EventSource.builder()
-                .id(1L)
-                .aggregateId(11L)
-                .payload(john)
-                .seq(1L)
-                .occurredAt(LocalDateTime.now())
-                .build();
+        Event e = EventMaker.make(eventId(1L), aggregateId(11L), seq(1L), eventName(john.getClass().getName()), occurredAt(LocalDateTime.now()), payload(john));
 
         eventStorage.save(e);
 

--- a/event/storage-jdbc/src/test/java/io/agistep/event/storages/JDBCEventStorage_Optimistic_Lock_Test.java
+++ b/event/storage-jdbc/src/test/java/io/agistep/event/storages/JDBCEventStorage_Optimistic_Lock_Test.java
@@ -1,7 +1,7 @@
 package io.agistep.event.storages;
 
 import io.agistep.event.Event;
-import io.agistep.event.EventSource;
+import io.agistep.event.EventMaker;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -9,12 +9,11 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
+import static io.agistep.event.EventMaker.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SuppressWarnings("ClassNamingConvention")
 class JDBCEventStorage_Optimistic_Lock_Test {
-
-    private static String ANY_EVENT_NAME = "io.agistep.event.storages.ProtoPayload";
 
     JDBCEventStorage eventStorage;
 
@@ -43,11 +42,6 @@ class JDBCEventStorage_Optimistic_Lock_Test {
         record Person(String name, int age) {}
 
         Person john = new Person("John", 30);
-        return EventSource.builder()
-                .id(13L)
-                .aggregateId(5L)
-                .payload(john)
-                .seq(seq0)
-                .occurredAt(LocalDateTime.now()).build();
+        return EventMaker.make(eventId(13L), aggregateId(5L), seq(seq0), eventName(john.getClass().getName()), occurredAt(LocalDateTime.now()), payload(john));
     }
 }

--- a/event/storage-jdbc/src/test/java/io/agistep/event/storages/JDBCEventStorage_Protobuf_Test.java
+++ b/event/storage-jdbc/src/test/java/io/agistep/event/storages/JDBCEventStorage_Protobuf_Test.java
@@ -1,18 +1,17 @@
 package io.agistep.event.storages;
 
 import io.agistep.event.Event;
-import io.agistep.event.EventSource;
+import io.agistep.event.EventMaker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static io.agistep.event.EventMaker.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JDBCEventStorage_Protobuf_Test {
-
-    private static String ANY_EVENT_NAME = "io.agistep.event.storages.ProtoPayload";
 
     JDBCEventStorage eventStorage;
 
@@ -28,12 +27,7 @@ class JDBCEventStorage_Protobuf_Test {
 
         ProtoPayload build = ProtoPayload.newBuilder().setBody("foo-body").build();
 
-        Event e = EventSource.builder()
-                .id(12L)
-                .aggregateId(12L)
-                .payload(build)
-                .seq(1L)
-                .occurredAt(LocalDateTime.now()).build();
+        Event e = EventMaker.make(eventId(12L), aggregateId(12L), seq(1L), eventName(build.getClass().getName()), occurredAt(LocalDateTime.now()), payload(build));
 
         eventStorage.save(e);
 

--- a/event/storage-jdbc/src/test/java/io/agistep/event/storages/JDBCEventStorage_Serializer_test.java
+++ b/event/storage-jdbc/src/test/java/io/agistep/event/storages/JDBCEventStorage_Serializer_test.java
@@ -1,7 +1,7 @@
 package io.agistep.event.storages;
 
 import io.agistep.event.Event;
-import io.agistep.event.EventSource;
+import io.agistep.event.EventMaker;
 import io.agistep.event.Serializer;
 import io.agistep.event.serialization.JsonSerializer;
 import io.agistep.event.serialization.ProtocolBufferSerializer;
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import java.time.LocalDateTime;
 
+import static io.agistep.event.EventMaker.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 
@@ -39,13 +40,8 @@ class JDBCEventStorage_Serializer_test {
         eventStorage.setSerializer(jsonSerializerSpy);
         JsonPayloadTest testAnEventPayload = new JsonPayloadTest("Test anEvent");
 
-        Event anEvent = EventSource.builder()
-                .id(2L)
-                .seq(0L)
-                .aggregateId(1L)
-                .payload(testAnEventPayload)
-                .occurredAt(LocalDateTime.of(2023,12,12,0,0))
-                .build();
+        Event anEvent = EventMaker.make(eventId(13L), aggregateId(5L), seq(0L), eventName(testAnEventPayload.getClass().getName()), occurredAt(LocalDateTime.of(2023,12,12,0,0)), payload(testAnEventPayload));
+
 
         eventStorage.save(anEvent);
 

--- a/event/storage/src/test/java/io/agistep/event/storages/MapEventStorage_Optimistic_Locking_Test.java
+++ b/event/storage/src/test/java/io/agistep/event/storages/MapEventStorage_Optimistic_Locking_Test.java
@@ -1,11 +1,15 @@
 package io.agistep.event.storages;
 
 import io.agistep.event.Event;
-import io.agistep.event.EventSource;
+import io.agistep.event.EventMaker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+
+import static io.agistep.event.EventMaker.*;
+import static io.agistep.event.EventMaker.payload;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SuppressWarnings("ClassNamingConvention")
@@ -13,30 +17,10 @@ class MapEventStorage_Optimistic_Locking_Test {
 
     MapEventStorage sut;
 
-    Event anEvent1 = EventSource.builder()
-            .id(1L)
-            .seq(0L)
-
-            .aggregateId(1L)
-            .payload(TestPayload.of("Hello~~~"))
-            .build();
-
-    Event anEvent2 = EventSource.builder()
-            .id(1L)
-            .seq(1L)
-
-            .aggregateId(1L)
-
-            .payload(TestPayload.of("Hello~~~"))
-            .build();
-
-    Event anEvent3 = EventSource.builder()
-            .id(1L)
-            .seq(1L)
-            .aggregateId(1L)
-            .payload(TestPayload.of("Hello~~~"))
-            .build();
-
+    TestPayload payload = TestPayload.of("Hello~~~");
+    Event anEvent1 = EventMaker.make(eventId(1L), aggregateId(1L), seq(0L), eventName(payload.getClass().getName()), occurredAt(LocalDateTime.now()), payload(payload));
+    Event anEvent2 = EventMaker.make(eventId(1L), aggregateId(1L), seq(1L), eventName(payload.getClass().getName()), occurredAt(LocalDateTime.now()), payload(payload));
+    Event anEvent3 = EventMaker.make(eventId(1L), aggregateId(1L), seq(1L), eventName(payload.getClass().getName()), occurredAt(LocalDateTime.now()), payload(payload));
 
     @BeforeEach
     void setUp() {

--- a/event/storage/src/test/java/io/agistep/event/storages/MapEventStorage_Save_And_Find_Test.java
+++ b/event/storage/src/test/java/io/agistep/event/storages/MapEventStorage_Save_And_Find_Test.java
@@ -1,15 +1,16 @@
 package io.agistep.event.storages;
 
 import io.agistep.event.Event;
-import io.agistep.event.EventSource;
+import io.agistep.event.EventMaker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
 
+import static io.agistep.event.EventMaker.*;
+import static io.agistep.event.EventMaker.payload;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("ClassNamingConvention")
@@ -17,13 +18,8 @@ class MapEventStorage_Save_And_Find_Test {
 
     MapEventStorage sut;
 
-    Event anEvent = EventSource.builder()
-            .id(1L)
-            .seq(0L)
-            .aggregateId(1L)
-            .payload(TestPayload.of("Hello~~~"))
-            .occurredAt(LocalDateTime.of(2023,12,12,0,0))
-            .build();
+    TestPayload payload = TestPayload.of("Hello~~~");
+    Event anEvent = EventMaker.make(eventId(1L), aggregateId(1L), seq(0L), eventName(payload.getClass().getName()), occurredAt(LocalDateTime.of(2023,12,12,0,0)), payload(payload));
 
     @BeforeEach
     void setUp() {

--- a/event/storage/src/test/java/io/agistep/event/storages/MapEventStorage_Serializer_Test.java
+++ b/event/storage/src/test/java/io/agistep/event/storages/MapEventStorage_Serializer_Test.java
@@ -1,7 +1,7 @@
 package io.agistep.event.storages;
 
 import io.agistep.event.Event;
-import io.agistep.event.EventSource;
+import io.agistep.event.EventMaker;
 import io.agistep.event.serialization.JsonSerializer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,6 +11,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 
+import static io.agistep.event.EventMaker.*;
+import static io.agistep.event.EventMaker.payload;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -24,13 +26,8 @@ class MapEventStorage_Serializer_Test {
 
     @Test
     void JsonSerializer_test() {
-        Event anEvent = EventSource.builder()
-                .id(1L)
-                .seq(0L)
-                .aggregateId(1L)
-                .payload(new JsonPayloadTest("value"))
-                .occurredAt(LocalDateTime.of(2023, 12, 12, 0, 0))
-                .build();
+        JsonPayloadTest payload = new JsonPayloadTest("value");
+        Event anEvent = EventMaker.make(eventId(1L), aggregateId(1L), seq(0L), eventName(payload.getClass().getName()), occurredAt(LocalDateTime.of(2023,12,12,0,0)), payload(payload));
 
         JsonSerializer serializer = Mockito.spy(new JsonSerializer());
         sut = new MapEventStorage(new HashMap<>());
@@ -42,13 +39,8 @@ class MapEventStorage_Serializer_Test {
 
     @Test
     void JsonDeSerializer_test() {
-        Event anEvent = EventSource.builder()
-                .id(1L)
-                .seq(0L)
-                .aggregateId(1L)
-                .payload(new JsonPayloadTest("value"))
-                .occurredAt(LocalDateTime.of(2023, 12, 12, 0, 0))
-                .build();
+        JsonPayloadTest payload = new JsonPayloadTest("value");
+        Event anEvent = EventMaker.make(eventId(1L), aggregateId(1L), seq(0L), eventName(payload.getClass().getName()), occurredAt(LocalDateTime.of(2023,12,12,0,0)), payload(payload));
 
         sut = new MapEventStorage(new HashMap<>());
 

--- a/event/test-supports/src/main/java/io/agistep/event/test/EventFixtureBuilder.java
+++ b/event/test-supports/src/main/java/io/agistep/event/test/EventFixtureBuilder.java
@@ -2,6 +2,7 @@ package io.agistep.event.test;
 
 import io.agistep.aggregator.IdUtils;
 import io.agistep.event.Event;
+import io.agistep.event.EventMaker;
 import io.agistep.event.EventSource;
 
 import java.time.LocalDateTime;
@@ -9,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static io.agistep.event.EventMaker.*;
 import static io.agistep.event.EventSource.INITIAL_SEQ;
 import static org.hamcrest.CoreMatchers.*;
 import static org.valid4j.Validation.validate;
@@ -60,25 +62,27 @@ public final class EventFixtureBuilder {
         long latestSeq = EventSource.getLatestSeqOf(this.aggregateId);
         AtomicLong seq = new AtomicLong(latestSeq ==-1 ? INITIAL_SEQ : latestSeq );
 
-        return payloads.stream().map(p-> EventSource.builder()
-                .id(eventId.getAndIncrement())
-                .seq(seq.getAndIncrement())
-                .aggregateId(this.aggregateId)
-                .payload(p)
-                .occurredAt(LocalDateTime.now())
-                .build()).toList().toArray(new Event[0]);
+        return payloads.stream().map(p-> EventMaker.make(
+                eventId(eventId.getAndIncrement()),
+                aggregateId(this.aggregateId),
+                seq(seq.getAndIncrement()),
+                eventName(p.getClass().getName()),
+                occurredAt(LocalDateTime.now()),
+                payload(p))
+        ).toList().toArray(new Event[0]);
     }
 
     public Event[] build(long beginSeq) {
         AtomicLong eventId = new AtomicLong(getId());
         AtomicLong seq = new AtomicLong(beginSeq == -1 ? INITIAL_SEQ : ++beginSeq);
 
-        return payloads.stream().map(p-> EventSource.builder()
-                .id(eventId.getAndIncrement())
-                .seq(seq.getAndIncrement())
-                .aggregateId(this.aggregateId)
-                .payload(p)
-                .occurredAt(LocalDateTime.now())
-                .build()).toList().toArray(new Event[0]);
+        return payloads.stream().map(p-> EventMaker.make(
+                eventId(eventId.getAndIncrement()),
+                aggregateId(this.aggregateId),
+                seq(seq.getAndIncrement()),
+                eventName(p.getClass().getName()),
+                occurredAt(LocalDateTime.now()),
+                payload(p))
+        ).toList().toArray(new Event[0]);
     }
 }


### PR DESCRIPTION
EventMaker 로 분리하면서 event name 에 대해 validate 추가해서 issue의 요구사항 2, 3 을 포함하려 해보았습니다.
현 방향의 목적이 event name 을 event apply 시 지정할 수 있도록 하는 비즈니스적인 로직을 표현하기 위해 인 것 같아 apply 시 이벤트 이름을 사용자가 지정할 수 있게 행위의 규약을 변경했는데 제가 이해한 것이 맞는지 불분명해서..

리뷰 피드백 받고 관련해 기존 소스를 수정/삭제 하려고 합니다.

- 지난주 피드백
  - EventMaker 가 이벤트 생성의 책임을 갖고, maker만 builder를 사용하여 event 를 만들 수 있어야 한다.
- 금주 피드백 한번 더 듣고 현재 EventBuilder 사용 중인 코드 변경 적용 예정